### PR TITLE
Implement a CDbfReader::JumpToLastRecord function.

### DIFF
--- a/CDbfReader.h
+++ b/CDbfReader.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <fstream>
 #include <memory>
+#include <numeric>
 #include <string>
 #include <variant>
 #include <vector>
@@ -29,7 +30,8 @@ public:
     std::variant<size_t, CDbfError> GetFieldIndex(const std::string& strField) const;
     const std::vector<FieldInfo>& GetFields() const { return m_Fields; }
     std::variant<std::vector<std::string>, std::monostate, CDbfError> ReadNextRecord();
-    void ResetToFirstRecord();
+    void JumpToFirstRecord();
+    std::variant<std::monostate, CDbfError> JumpToLastRecord();
 
 private:
     size_t m_DataStart;


### PR DESCRIPTION
This performs much better than calling CDbfReader::ReadNextRecord and preserving the returned std::vector<std::string> for each record.
For consistency, ResetToFirstRecord has also been renamed to JumpToFirstRecord.

Profiling was conducted with Very Sleepy CS 0.90 (last version supporting Windows XP).