### PR TITLE
Pass `wchar_t*` to `std::ifstream::open` to prevent implicit UTF16->ANSI

### DIFF
--- a/src/CDbfReader.cpp
+++ b/src/CDbfReader.cpp
@@ -26,7 +26,7 @@ _ReadDbt(std::ifstream& DbtFile, const std::wstring& wstrDbfFilePath)
     wstrDbtFilePath.pop_back();
     wstrDbtFilePath.push_back(L't');
 
-    DbtFile.open(wstrDbtFilePath, std::ios::binary);
+    DbtFile.open(wstrDbtFilePath.c_str(), std::ios::binary);
     if (!DbtFile)
     {
         return CDbfError(L"Could not open DBT memo file \"" + wstrDbtFilePath + L"\"");
@@ -105,7 +105,7 @@ std::variant<std::unique_ptr<CDbfReader>, CDbfError>
 CDbfReader::ReadDbf(const std::wstring& wstrDbfFilePath)
 {
     // Open the .dbf file for reading.
-    std::ifstream DbfFile(wstrDbfFilePath, std::ios::binary);
+    std::ifstream DbfFile(wstrDbfFilePath.c_str(), std::ios::binary);
     if (!DbfFile)
     {
         return CDbfError(L"Could not open \"" + wstrDbfFilePath + L"\"");


### PR DESCRIPTION
The previously passed `const std::wstring&` was implicitly converted to an `std::filesystem::path`. That library is still considered experimental in the used libc++ release, so it should be avoided outright. Even worse, this version performs an implicit UTF16->ANSI conversion, breaking all efforts of consistent Unicode usage.